### PR TITLE
fix(shefi-new): route primary-name setup through name profile page

### DIFF
--- a/packages/shefi-new/src/components/SetPrimaryNameModal.tsx
+++ b/packages/shefi-new/src/components/SetPrimaryNameModal.tsx
@@ -153,6 +153,9 @@ export function SetPrimaryNameModal({
   };
 
   const handleSkip = () => {
+    if (isLoading || isSwitching) {
+      return;
+    }
     setIsLoading(false);
     onClose();
   };

--- a/packages/shefi-new/src/hooks/useTransactionModal.tsx
+++ b/packages/shefi-new/src/hooks/useTransactionModal.tsx
@@ -45,6 +45,9 @@ export function useTransactionModal(options: UseTransactionModalOptions = {}) {
   );
 
   const closeTransactionModal = useCallback(() => {
+    if (status === 'pending') {
+      return;
+    }
     setIsOpen(false);
     // Reset after animation
     setTimeout(() => {
@@ -52,7 +55,7 @@ export function useTransactionModal(options: UseTransactionModalOptions = {}) {
       setStatus('pending');
       setErrorMessage(null);
     }, 200);
-  }, []);
+  }, [status]);
 
   /**
    * Wait for a transaction with retry logic


### PR DESCRIPTION
## Summary
- route the post-registration "Set Primary Name" action directly to `/name/[label]` instead of opening the modal on the register screen
- auto-open the primary-name modal on the profile page via `openPrimaryModal=1`, then clean the URL to avoid reopening on refresh
- harden modal UX by preventing accidental close while pending/switching and keeping auto-open behavior reliable across name-route changes

## Test plan
- [x] Register a new name, click "Set Primary Name", confirm navigation goes to `/name/[label]` and modal opens there
- [x] Complete primary-name setup and verify success state remains on the profile page
- [x] Cancel/switch-network during setup and confirm modal does not unexpectedly dismiss mid-action
- [x] Refresh `/name/[label]` after auto-open trigger and verify modal does not reopen due to stale query param
- [ ] `npm run lint` in `packages/shefi-new` (currently prompts for first-time Next.js ESLint setup)

Made with [Cursor](https://cursor.com)