### PR TITLE
feat(pizzadaoo): pre-check parent eligibility before register

### DIFF
--- a/packages/pizzadaoo/src/components/MintForm.tsx
+++ b/packages/pizzadaoo/src/components/MintForm.tsx
@@ -22,6 +22,11 @@ import {
 } from "@namespacesdk/mint-manager";
 import { debounce } from "../utils/debounce";
 import { getTxErrorMessage, isUserRejection } from "../utils/txError";
+import {
+  checkEligibility,
+  type EligibilityResult,
+} from "../utils/eligibility";
+import { mainnet } from "wagmi/chains";
 
 // Lazily created so the SDK is not initialised (and does not log) at module
 // import time during SSR/build.
@@ -70,6 +75,10 @@ export const MintForm = () => {
   });
   const [mintedName, setMintedName] = useState<string | null>(null);
   const [mintError, setMintError] = useState<string | null>(null);
+  const [eligibility, setEligibility] = useState<EligibilityResult>({
+    status: "idle",
+  });
+  const mainnetClient = usePublicClient({ chainId: mainnet.id });
 
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -78,6 +87,29 @@ export const MintForm = () => {
       mountedRef.current = false;
     };
   }, []);
+
+  // Re-run the eligibility check whenever the user connects a wallet, changes
+  // accounts, or switches the selected parent. Surfaces gate-specific errors
+  // (whitelist / token-gate) before they hit the Register button.
+  useEffect(() => {
+    let cancelled = false;
+    if (!address) {
+      setEligibility({ status: "idle" });
+      return;
+    }
+    setEligibility({ status: "checking" });
+    void (async () => {
+      const result = await checkEligibility(
+        selectedPizzaName.fullName,
+        address,
+        { mainnet: mainnetClient, base: publicClient },
+      );
+      if (!cancelled) setEligibility(result);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [address, selectedPizzaName.fullName, mainnetClient, publicClient]);
 
   const checkAvailable = async (value: string) => {
     try {
@@ -291,10 +323,13 @@ export const MintForm = () => {
   const needsChainSwitch = Boolean(address) && isWrongChain;
   const isBusy = mintState.waitingWallet || mintState.waitingTx;
   const fullName = `${searchLabel}.${selectedPizzaName.fullName}`;
+  const isGateBlocking =
+    eligibility.status === "ineligible" || eligibility.status === "checking";
   const mintBtnDisabled =
     searchLabel.length === 0 ||
     availability !== "available" ||
-    isBusy;
+    isBusy ||
+    isGateBlocking;
 
   const registerLabel = mintState.waitingWallet
     ? "Confirm in wallet…"
@@ -363,6 +398,7 @@ export const MintForm = () => {
                 status={availability}
                 hasInput={searchLabel.length > 0}
                 fullName={fullName}
+                eligibility={eligibility}
               />
 
               <div className="mt-2">
@@ -424,11 +460,33 @@ const AvailabilityHint = ({
   status,
   hasInput,
   fullName,
+  eligibility,
 }: {
   status: AvailabilityStatus;
   hasInput: boolean;
   fullName: string;
+  eligibility: EligibilityResult;
 }) => {
+  // Eligibility takes priority — if the wallet can't mint here at all there's
+  // no point inviting them to check names. Detailed copy lives in
+  // instructionText above; here we keep it short ("Wallet not whitelisted",
+  // "You don't hold a Rare Pizzas Box").
+  if (eligibility.status === "ineligible" && eligibility.reason) {
+    return (
+      <p className="availability is-unavailable" aria-live="polite">
+        <span className="avail-dot" aria-hidden="true" />
+        {eligibility.reason}
+      </p>
+    );
+  }
+  if (eligibility.status === "checking") {
+    return (
+      <p className="availability is-checking" aria-live="polite">
+        Checking your wallet…
+      </p>
+    );
+  }
+
   // Reserve the row height so the layout never shifts as state changes.
   let content: React.ReactNode = " ";
   let tone = "";
@@ -451,12 +509,12 @@ const AvailabilityHint = ({
     content = (
       <>
         <span className="avail-dot" aria-hidden="true" />
-        That name isn&apos;t available
+        Already taken
       </>
     );
     tone = "is-unavailable";
   } else if (status === "error") {
-    content = "Couldn't check — try a different name";
+    content = "Couldn't check that name";
     tone = "is-error";
   }
 

--- a/packages/pizzadaoo/src/utils/eligibility.ts
+++ b/packages/pizzadaoo/src/utils/eligibility.ts
@@ -1,0 +1,118 @@
+import type { PublicClient } from "viem";
+import {
+  getListingGate,
+  type ListingGate,
+  type TokenGate,
+} from "./listingConfig";
+
+export type EligibilityStatus =
+  | "idle"
+  | "checking"
+  | "eligible"
+  | "ineligible"
+  | "unknown";
+
+export interface EligibilityResult {
+  status: EligibilityStatus;
+  /** Short, hint-row-sized reason. Detailed copy belongs in instructionText. */
+  reason?: string;
+}
+
+const erc721BalanceAbi = [
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "owner", type: "address" }],
+    outputs: [{ type: "uint256" }],
+  },
+] as const;
+
+/**
+ * Friendly names for known gate tokens. Used in the hint row when telling
+ * the user which NFT they need to hold. Extend as new listings ship.
+ */
+const KNOWN_TOKENS: Record<string, { name: string }> = {
+  // Rare Pizzas Box — pizzamafia.eth gate
+  "0x4ae57798aef4af99ed03818f83d2d8aca89952c7": { name: "Rare Pizzas Box" },
+};
+
+function tokenLabel(address: string) {
+  return (
+    KNOWN_TOKENS[address.toLowerCase()] ?? {
+      name: `${address.slice(0, 6)}…${address.slice(-4)}`,
+    }
+  );
+}
+
+async function ownsAny(
+  gates: TokenGate[],
+  address: `0x${string}`,
+  clients: { mainnet?: PublicClient; base?: PublicClient },
+): Promise<boolean> {
+  for (const g of gates) {
+    const client =
+      g.tokenNetwork === "MAINNET" ? clients.mainnet : clients.base;
+    if (!client) continue;
+    try {
+      const balance = (await client.readContract({
+        abi: erc721BalanceAbi,
+        address: g.tokenAddress,
+        functionName: "balanceOf",
+        args: [address],
+      })) as bigint;
+      if (balance > BigInt(0)) return true;
+    } catch {
+      // Treat read failures as inconclusive — let the loop continue, but
+      // don't pretend the user holds the token.
+    }
+  }
+  return false;
+}
+
+export async function checkEligibility(
+  parentName: string,
+  address: `0x${string}` | undefined,
+  clients: { mainnet?: PublicClient; base?: PublicClient },
+): Promise<EligibilityResult> {
+  if (!address) return { status: "idle" };
+
+  const gate: ListingGate | null = await getListingGate(parentName);
+
+  // No listing info from list-manager — treat as not open for direct mint.
+  // pizzadao.eth currently lands here: list-manager returns 200 with empty
+  // body, which lines up with the existing "ask a Capo or DPR" instruction.
+  if (!gate) {
+    return { status: "ineligible", reason: "Direct mint isn't open" };
+  }
+
+  const hasWhitelist = gate.whitelistWallets.length > 0;
+  const hasTokenGate = gate.tokenGates.length > 0;
+
+  // Type 1 — pure address whitelist (e.g., rarepizzas.eth, enscomponent.eth).
+  if (gate.whitelistType === 1 && hasWhitelist) {
+    const isWhitelisted = gate.whitelistWallets.includes(
+      address.toLowerCase(),
+    );
+    if (isWhitelisted) return { status: "eligible" };
+    return {
+      status: "ineligible",
+      reason: "Your wallet isn't on the allowlist",
+    };
+  }
+
+  // Type 2 (or otherwise) with a token gate — verifiedMinter pattern.
+  // Anyone holding any gate token can mint.
+  if (hasTokenGate) {
+    const owns = await ownsAny(gate.tokenGates, address, clients);
+    if (owns) return { status: "eligible" };
+    const { name } = tokenLabel(gate.tokenGates[0].tokenAddress);
+    return {
+      status: "ineligible",
+      reason: `You need a ${name} in this wallet`,
+    };
+  }
+
+  // No gates documented — open mint.
+  return { status: "eligible" };
+}

--- a/packages/pizzadaoo/src/utils/listingConfig.ts
+++ b/packages/pizzadaoo/src/utils/listingConfig.ts
@@ -1,0 +1,69 @@
+/**
+ * Fetch + cache list-manager listing config so we can show eligibility
+ * upfront — before the user submits a mint that's destined to revert with
+ * `MINTER_NOT_WHITELISTED` or `MINTER_NOT_TOKEN_OWNER`.
+ */
+
+export type TokenGateNetwork = "MAINNET" | "BASE";
+
+export interface TokenGate {
+  tokenType: "ERC721" | "ERC1155" | string;
+  tokenAddress: `0x${string}`;
+  tokenNetwork: TokenGateNetwork;
+}
+
+export interface ListingGate {
+  /** 1 = address whitelist, 2 = verifiedMinter (signature-based, paired with tokenGates) */
+  whitelistType: number | null;
+  /** Lower-cased addresses for cheap comparison. */
+  whitelistWallets: string[];
+  tokenGates: TokenGate[];
+}
+
+const LIST_MANAGER =
+  "https://list-manager.namespace.ninja/api/v1/listing/network/MAINNET/name/";
+
+const cache = new Map<string, ListingGate | null>();
+const inFlight = new Map<string, Promise<ListingGate | null>>();
+
+export async function getListingGate(
+  parentName: string,
+): Promise<ListingGate | null> {
+  if (cache.has(parentName)) return cache.get(parentName) ?? null;
+
+  const pending = inFlight.get(parentName);
+  if (pending) return pending;
+
+  const p = (async () => {
+    try {
+      const res = await fetch(LIST_MANAGER + encodeURIComponent(parentName));
+      if (!res.ok) {
+        cache.set(parentName, null);
+        return null;
+      }
+      const text = await res.text();
+      if (!text) {
+        cache.set(parentName, null);
+        return null;
+      }
+      const data = JSON.parse(text);
+      const gate: ListingGate = {
+        whitelistType: data?.whitelist?.type ?? null,
+        whitelistWallets: (data?.whitelist?.wallets ?? []).map((a: string) =>
+          a.toLowerCase(),
+        ),
+        tokenGates: data?.tokenGatedAccess ?? [],
+      };
+      cache.set(parentName, gate);
+      return gate;
+    } catch {
+      cache.set(parentName, null);
+      return null;
+    } finally {
+      inFlight.delete(parentName);
+    }
+  })();
+
+  inFlight.set(parentName, p);
+  return p;
+}


### PR DESCRIPTION
## Summary

- Resolves on-chain reverts users used to discover only after clicking Register (`MINTER_NOT_WHITELISTED`, `MINTER_NOT_TOKEN_OWNER`).
- Fetches each parent's list-manager config once (in-memory cached + in-flight de-duped), evaluates it against the connected wallet (with an ERC-721 `balanceOf` on token gates), and surfaces a short blocker in the same availability hint row.
- Register button stays disabled while eligibility is `checking` or `ineligible`.

## What surfaces in the hint row

| Parent gate | Copy |
|---|---|
| Whitelist type 1, wallet not in it (`rarepizzas.eth`, `enscomponent.eth`) | "Your wallet isn't on the allowlist" |
| Token gate, no NFT (`pizzamafia.eth` → Rare Pizzas Box) | "You need a Rare Pizzas Box in this wallet" |
| Unlisted in list-manager (`pizzadao.eth` returns empty body) | "Direct mint isn't open" |
| Checking | "Checking your wallet…" |
| Eligible | (falls through to existing availability row) |

Detailed how-to copy already lives in the per-parent instruction text above the input, so the hint row stays short.

## Files

- `src/utils/listingConfig.ts` *(new, 69 LOC)* — list-manager fetch + per-parent cache + in-flight dedup
- `src/utils/eligibility.ts` *(new, 118 LOC)* — gate evaluation: type-1 whitelist, token gate, missing-listing; known-token name lookup (extend the table as new listings ship)
- `src/components/MintForm.tsx` — eligibility state, effect on `[address, parent]`, register-disable wiring, AvailabilityHint absorbs the eligibility row; also tightened "That name isn't available" → "Already taken"

## Test plan

- [ ] Connect a wallet that holds none of the gate NFTs and isn't on any whitelist. Cycle the four parent badges:
  - `pizzadao.eth` → "Direct mint isn't open"
  - `rarepizzas.eth` → "Your wallet isn't on the allowlist"
  - `pizzamafia.eth` → "You need a Rare Pizzas Box in this wallet"
  - `enscomponent.eth` → "Your wallet isn't on the allowlist" (assuming not whitelisted) OR falls through
  - Register button disabled in every case.
- [ ] Connect a wallet that owns a Rare Pizzas Box. Selecting `pizzamafia.eth` should fall through to "Type a name to check availability" and re-enable Register once a name is typed.
- [ ] Connect a whitelisted wallet for `enscomponent.eth`. Row should be the normal availability flow; rename swap still works end-to-end.
- [ ] Disconnect wallet. Row should show "Type a name to check availability" on initial load.
- [ ] Switch parents rapidly — the in-flight dedup should mean only one fetch per parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)