### PR TITLE
feat(pizzadaoo): inject NEXT_PUBLIC_ALCHEMY_KEY at Docker build time

### DIFF
--- a/.github/workflows/pizza-dao.yaml
+++ b/.github/workflows/pizza-dao.yaml
@@ -12,26 +12,27 @@ jobs:
         node-version: [20.x]
 
     steps:
-    
-    - name: Checkout branch
-      uses: actions/checkout@v2
+      - name: Checkout branch
+        uses: actions/checkout@v2
 
-    - name: Setup node and npm
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Setup node and npm
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        registry: ${{secrets.CR_URL}}
-        username: ${{secrets.CR_USERNAME}}
-        password: ${{secrets.CR_PASSWORD}}
-    
-    - name: Build and push
-      uses: docker/build-push-action@v4
-      with:
-        context: ./packages/pizzadaoo
-        file: ./packages/pizzadaoo/Dockerfile
-        push: true
-        tags: ${{secrets.CR_URL}}/pizzadao-dapp:latest
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ${{secrets.CR_URL}}
+          username: ${{secrets.CR_USERNAME}}
+          password: ${{secrets.CR_PASSWORD}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: ./packages/pizzadaoo
+          file: ./packages/pizzadaoo/Dockerfile
+          push: true
+          tags: ${{secrets.CR_URL}}/pizzadao-dapp:latest
+          build-args: |
+            NEXT_PUBLIC_ALCHEMY_KEY=${{ secrets.NEXT_PUBLIC_ALCHEMY_KEY }}

--- a/packages/pizzadaoo/Dockerfile
+++ b/packages/pizzadaoo/Dockerfile
@@ -13,6 +13,12 @@ RUN npm install
 # Copy the rest of the application code
 COPY . .
 
+# NEXT_PUBLIC_* vars are inlined into the client bundle at build time, so they
+# must exist BEFORE `npm run build`. They arrive as a --build-arg from CI and
+# are promoted to an ENV so Next.js can read them during the build below.
+ARG NEXT_PUBLIC_ALCHEMY_KEY
+ENV NEXT_PUBLIC_ALCHEMY_KEY=$NEXT_PUBLIC_ALCHEMY_KEY
+
 # Build the Next.js app
 RUN npm run build
 
@@ -20,4 +26,4 @@ RUN npm run build
 EXPOSE 3000
 
 # Start the application
-CMD ["yarn", "start"]
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Problem

ENS **primary-name (reverse) resolution** fails intermittently in the deployed PizzaDAO dapp — wallets connect but no `.eth` name shows.

Root cause: `NEXT_PUBLIC_*` env vars are **inlined into the client bundle at build time** (`npm run build`), not read at container runtime. The key was never present during the Docker build, so `process.env.NEXT_PUBLIC_ALCHEMY_KEY` compiled to `undefined` and every transport in `WalletConnect.tsx` collapsed to viem's rate-limited public RPC. The multi-call reverse-ENS sequence (`getEnsName`) gets throttled there.

Setting the key as a Cloud Run **runtime** env does nothing for `NEXT_PUBLIC_*` — the value is already frozen in the image.

## Fix

- **Dockerfile**: accept `NEXT_PUBLIC_ALCHEMY_KEY` as an `ARG` and promote it to `ENV` *before* `RUN npm run build`, so Next.js inlines the real Alchemy URL.
- **Workflow**: pass the key to `docker/build-push-action` via `build-args` from a GitHub secret.
- Align the start command with the rest of the Dockerfile (`npm run start`; the project uses npm + `package-lock.json`, no `yarn.lock`).

## Required before this works

Add a repo Actions secret: **`NEXT_PUBLIC_ALCHEMY_KEY`** = the Alchemy app key.

> ⚠️ This key ships to the browser (that's what `NEXT_PUBLIC_` means). Use a **dedicated Alchemy app** with a **domain/referrer allowlist** restricted to the Cloud Run origin so a scraped key can't burn compute units.

## Not touched (by design)

Server-side `swap.ts` already resolves its RPC from `BASE_RPC_URL` (a plain Cloud Run **runtime** env), falling back to the public key only if unset. No change needed there — set `BASE_RPC_URL` in Cloud Run to rotate the server RPC without a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)