### PR TITLE
feat(pizzadaoo): optimistic rename UI + default address on remint

### DIFF
--- a/packages/pizzadaoo/src/components/MySubnames.scss
+++ b/packages/pizzadaoo/src/components/MySubnames.scss
@@ -105,6 +105,39 @@
             white-space: nowrap;
         }
 
+        &__syncing {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            flex-shrink: 0;
+            font-size: 12px;
+            line-height: 1;
+            letter-spacing: 0.02em;
+            text-transform: lowercase;
+            color: $green;
+            opacity: 0.85;
+        }
+
+        &__syncing-dot {
+            width: 7px;
+            height: 7px;
+            border-radius: 50%;
+            background-color: $green;
+            animation: subname-syncing-pulse 1.1s ease-in-out infinite;
+        }
+
+        @keyframes subname-syncing-pulse {
+            0%,
+            100% {
+                opacity: 0.3;
+                transform: scale(0.8);
+            }
+            50% {
+                opacity: 1;
+                transform: scale(1.15);
+            }
+        }
+
         &__chevron {
             margin-left: auto;
             font-size: 22px;

--- a/packages/pizzadaoo/src/components/MySubnames.tsx
+++ b/packages/pizzadaoo/src/components/MySubnames.tsx
@@ -70,6 +70,9 @@ export const MySubnames = () => {
     items: [],
     totalItems: 0,
   });
+  // Name of the optimistically-inserted rename result still awaiting the
+  // indexer. Drives the "syncing…" badge on that row.
+  const [syncingName, setSyncingName] = useState<string | null>(null);
 
   const selectedQuery = router.query.selected;
 
@@ -106,10 +109,34 @@ export const MySubnames = () => {
     };
   }, [address, selectedQuery]);
 
+  // Optimistically reflect a successful rename before the indexer catches
+  // up: prepend the new name (carrying over avatar/addresses/texts, which
+  // the swap preserves on-chain) and drop the burned old one. Count is
+  // unchanged — burn 1, mint 1. Marking it as a swap result also flips
+  // `alreadySwapped` immediately, so the Rename action disappears at once.
+  const applyOptimisticRename = (source: Subname, newName: string) => {
+    setSubnames((prev) => ({
+      fetching: false,
+      totalItems: prev.totalItems,
+      items: [
+        {
+          ...source,
+          name: newName,
+          label: newName.split(".")[0],
+          mintSource: "pizzadaoo-swap",
+        },
+        ...prev.items.filter((s) => s.name !== source.name),
+      ],
+    }));
+    setSyncingName(newName);
+  };
+
   // Re-fetch the owner's subnames. When `expectedName` is given (after a
   // rename) the indexer may lag the on-chain mint by a few seconds, so we
-  // poll until the new name shows up — keeping the current list visible
-  // meanwhile rather than flashing a skeleton.
+  // poll until the new name shows up, then adopt the indexer's truth and
+  // clear the syncing badge. If it never shows within the window, we keep
+  // the optimistic row (the name IS on-chain) and just drop the badge —
+  // reverting to stale indexer data would wrongly hide the rename.
   const refreshSubnames = async (expectedName?: string) => {
     if (!address) {
       return;
@@ -117,20 +144,21 @@ export const MySubnames = () => {
     const maxAttempts = expectedName ? 8 : 1;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const res = await fetchSubnames(address);
-      const settled =
-        !expectedName ||
-        res.subnames.some((s) => s.name === expectedName) ||
-        attempt === maxAttempts - 1;
-      if (settled) {
+      const found = !expectedName || res.subnames.some((s) => s.name === expectedName);
+      if (found) {
         setSubnames({
           fetching: false,
           items: res.subnames,
           totalItems: res.totalItems,
         });
+        setSyncingName(null);
         return;
       }
-      await new Promise((r) => setTimeout(r, 2000));
+      if (attempt < maxAttempts - 1) {
+        await new Promise((r) => setTimeout(r, 2000));
+      }
     }
+    setSyncingName(null);
   };
 
   const filterApplied = searchFilter.length > 0;
@@ -157,8 +185,12 @@ export const MySubnames = () => {
           <SingleSubname
             onUpdate={(renamedTo) => {
               if (renamedTo) {
-                // The viewed name was burned by the rename — close the
-                // detail panel and poll the indexer for the new name.
+                // The viewed name was burned and the new one minted. Reflect
+                // it in the list immediately, then close the detail panel and
+                // poll the indexer to reconcile.
+                if (selectedSubname) {
+                  applyOptimisticRename(selectedSubname, renamedTo);
+                }
                 setSelectedSubname(undefined);
               }
               void refreshSubnames(renamedTo);
@@ -229,6 +261,19 @@ export const MySubnames = () => {
                 >
                   <SubnameAvatar subname={subname} />
                   <span className="txt">{subname.name}</span>
+                  {subname.name === syncingName && (
+                    <span
+                      className="subname-item__syncing"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      <span
+                        className="subname-item__syncing-dot"
+                        aria-hidden="true"
+                      />
+                      syncing…
+                    </span>
+                  )}
                   <span className="subname-item__chevron" aria-hidden="true">
                     ›
                   </span>

--- a/packages/pizzadaoo/src/pages/api/swap.ts
+++ b/packages/pizzadaoo/src/pages/api/swap.ts
@@ -307,6 +307,17 @@ export default async function handler(
       );
     }
 
+    // ENSIP-19 default-address coinType (0x80000000): the fallback any EVM
+    // chain falls through to when it has no explicit record. The remint mints
+    // to body.owner, so point the default at the owner — mirrors what the
+    // initial airdrop sets (scripts/airdrop.mjs) so renamed names resolve on
+    // every EVM chain, not just eth/base.
+    const ENSIP19_DEFAULT_COIN_TYPE = 2147483648;
+    mappedAddresses.push({
+      value: body.owner,
+      chain: ENSIP19_DEFAULT_COIN_TYPE,
+    });
+
     const records: EnsRecords = {
       texts: finalTexts,
       addresses: mappedAddresses,


### PR DESCRIPTION
Two UX fixes for the sponsored rename flow, branched off latest `master`.

## 1. Optimistic rename + syncing badge

**Problem:** after a swap succeeds, the indexer lags the on-chain mint by several seconds. During that window `refreshSubnames` kept the *old* list visible (to avoid a skeleton flash), so the burned name lingered, the new name was absent, and the list looked frozen — users refreshed manually. If indexer lag exceeded the ~16s poll window, the new name never appeared without a refresh.

**Fix** (`MySubnames.tsx` + `.scss`):
- On success, `applyOptimisticRename` prepends the new name (carrying over avatar/addresses/texts from the old entry, dropping the burned one). Count is unchanged (burn 1 + mint 1), and `mintSource: "pizzadaoo-swap"` flips `alreadySwapped` immediately so the Rename action disappears at once.
- A "⟳ syncing…" badge (pulsing dot) marks that row while the indexer is polled.
- `refreshSubnames` adopts indexer truth and clears the badge once the name appears. On poll exhaustion it **keeps** the optimistic row (the name is on-chain) and just clears the badge — reverting to stale indexer data would wrongly hide the rename.

## 2. Default address record on remint

**Problem:** `swap.ts` only set `eth` + `base` address records on the reissued name, so renamed names didn't resolve on other EVM chains. The initial airdrop (`scripts/airdrop.mjs`) already sets the ENSIP-19 default coinType, but the remint path didn't.

**Fix** (`swap.ts`): also set the ENSIP-19 default-address coinType (`0x80000000`) to the owner, so renamed names resolve on every EVM chain — matching the airdrop.

## Verification
- `tsc --noEmit` — clean
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)